### PR TITLE
Firewall Rule Based LED change

### DIFF
--- a/README_FIREWALLRULEBASEDLED
+++ b/README_FIREWALLRULEBASEDLED
@@ -1,0 +1,42 @@
+Drifting off into dream land ....
+
+It's 11pm and someone turns on a gaming system, you know this individual has a test or maybe a soccer game tomorrow, all the sudden your firewall'a state established LED turn on and glows red.
+
+I sprang from my bed to see what was the matter. Away to the TV I flew like a flash, tore open the door, and went with dash. When, what to my wondering eyes should appear, 
+the little one again with game controller in hand. Now little one you stand with a solemn face... go to bed ! Go to bed! Go back to bed now!"
+
+Reality is:
+You can also make the LED change to red based on firewall rules when they are live, take for example when running the following command inside of shell
+
+pfctl -vvsr
+
+This displays all the rule IDs, the rule I want to use for my system is 79 it is a gaming system. What I want to happen is the led change to on when that game system has an active state.
+
+pfctl -vvss will display all active states
+
+I want to check only on rule 79 so we grep it
+
+pfctl -vvss | grep ', rule 79'
+
+So now that I know this works and it matches the system I need
+
+I go into the fireall GUI and creat a file mine is /root/deviceonline
+
+add the following code
+
+#!/bin/sh
+pfctl -vvss | grep ', rule 79' >/dev/null
+res=$?
+if [ $res = 0 ]; then
+  sysctl -q dev.gpio.2.led.2.pwm=1
+  gpioctl -f /dev/gpioc2 6 duty 1 >/dev/null
+fi
+
+
+after chmod it 
+
+chmod +x /root/deviceonline
+
+and add a chron job to run when needed..
+
+When this rule goes active the LED will change state to red

--- a/deviceonline.sh
+++ b/deviceonline.sh
@@ -57,3 +57,75 @@ else
   gpioctl -f /dev/gpioc2 7 duty 0 >/dev/null
   gpioctl -f /dev/gpioc2 8 duty 0 >/dev/null
 fi
+
+Version with purple LED setting multiple colors on for same led
+
+#!/bin/sh
+pfctl -vvss | grep ', rule 79' >/dev/null
+res=$?
+if [ $res = 0 ]; 
+then
+  sysctl -q dev.gpio.2.led.1.pwm=1
+  gpioctl -f /dev/gpioc2 3 duty 100 >/dev/null
+  sysctl -q dev.gpio.2.led.2.pwm=1
+  gpioctl -f /dev/gpioc2 7 duty 0 >/dev/null
+  gpioctl -f /dev/gpioc2 6 duty 100 >/dev/null
+  gpioctl -f /dev/gpioc2 8 duty 100 >/dev/null
+else
+  sysctl -q dev.gpio.2.led.1.pwm=1
+  gpioctl -f /dev/gpioc2 3 duty 0 >/dev/null
+  sysctl -q dev.gpio.2.led.2.pwm=1
+  gpioctl -f /dev/gpioc2 6 duty 0 >/dev/null
+  gpioctl -f /dev/gpioc2 8 duty 0 >/dev/null
+  gpioctl -f /dev/gpioc2 7 duty 7 >/dev/null
+fi
+
+
+
+version with full variable to iterate over for multiple items variable is named state
+
+#!/bin/sh
+state=$( pfctl -vvss )
+res=1
+resb=1
+case "$state" in 
+  *, rule 79*)
+    res=0
+    ;;
+esac
+case "$state" in 
+  *192.168.1.11*)
+    resb=0
+    ;;
+esac
+if [ $res = 0 ] && [ $resb = 0 ]; 
+then
+  sysctl -q dev.gpio.2.led.1.pwm=1
+  gpioctl -f /dev/gpioc2 3 duty 50 >/dev/null
+  sysctl -q dev.gpio.2.led.2.pwm=1
+  gpioctl -f /dev/gpioc2 7 duty 0 >/dev/null
+  gpioctl -f /dev/gpioc2 6 duty 50 >/dev/null
+elif [ $res = 0 ];
+then
+  sysctl -q dev.gpio.2.led.1.pwm=1
+  gpioctl -f /dev/gpioc2 3 duty 0 >/dev/null
+  sysctl -q dev.gpio.2.led.2.pwm=1
+  gpioctl -f /dev/gpioc2 7 duty 0 >/dev/null
+  gpioctl -f /dev/gpioc2 6 duty 50 >/dev/null
+elif [ $resb = 0 ];
+then
+  sysctl -q dev.gpio.2.led.2.pwm=1
+  gpioctl -f /dev/gpioc2 7 duty 0 >/dev/null
+  gpioctl -f /dev/gpioc2 6 duty 0 >/dev/null
+  sysctl -q dev.gpio.2.led.1.pwm=1
+  gpioctl -f /dev/gpioc2 3 duty 50 >/dev/null
+else
+  sysctl -q dev.gpio.2.led.1.pwm=1
+  gpioctl -f /dev/gpioc2 3 duty 0 >/dev/null
+  sysctl -q dev.gpio.2.led.2.pwm=1
+  gpioctl -f /dev/gpioc2 6 duty 0 >/dev/null
+  gpioctl -f /dev/gpioc2 7 duty 50 >/dev/null
+  
+fi
+
+

--- a/deviceonline.sh
+++ b/deviceonline.sh
@@ -1,7 +1,59 @@
+
+Devive online version one led based
+
 #!/bin/sh
 pfctl -vvss | grep ', rule 79' >/dev/null
 res=$?
 if [ $res = 0 ]; then
   sysctl -q dev.gpio.2.led.2.pwm=1
   gpioctl -f /dev/gpioc2 6 duty 1 >/dev/null
+fi
+
+
+Device online version one led based will have green status 
+and Red will turn on when device with rule 79 goes online
+
+#!/bin/sh
+pfctl -vvss | grep ', rule 79' >/dev/null
+res=$?
+if [ $res = 0 ]; 
+then
+  sysctl -q dev.gpio.2.led.1.pwm=1
+  gpioctl -f /dev/gpioc2 3 duty 7 >/dev/null
+  sysctl -q dev.gpio.2.led.2.pwm=1
+  gpioctl -f /dev/gpioc2 6 duty 7 >/dev/null
+else
+  sysctl -q dev.gpio.2.led.1.pwm=1
+  gpioctl -f /dev/gpioc2 3 duty 0 >/dev/null
+  sysctl -q dev.gpio.2.led.2.pwm=1
+  gpioctl -f /dev/gpioc2 7 duty 7 >/dev/null
+fi
+
+Device online 3 led version all LEDs will light red when device is online and 
+go dark when device is offline
+
+#!/bin/sh
+pfctl -vvss | grep ', rule 79' >/dev/null
+res=$?
+if [ $res = 0 ]; 
+then
+  sysctl -q dev.gpio.2.led.0.pwm=1
+  gpioctl -f /dev/gpioc2 0 duty 200 >/dev/null
+  sysctl -q dev.gpio.2.led.1.pwm=1
+  gpioctl -f /dev/gpioc2 3 duty 200 >/dev/null
+  sysctl -q dev.gpio.2.led.2.pwm=1
+  gpioctl -f /dev/gpioc2 6 duty 200 >/dev/null
+else
+  sysctl -q dev.gpio.2.led.0.pwm=1
+  gpioctl -f /dev/gpioc2 0 duty 0 >/dev/null
+  gpioctl -f /dev/gpioc2 1 duty 0 >/dev/null
+  gpioctl -f /dev/gpioc2 2 duty 0 >/dev/null
+  sysctl -q dev.gpio.2.led.1.pwm=1
+  gpioctl -f /dev/gpioc2 3 duty 0 >/dev/null
+  gpioctl -f /dev/gpioc2 4 duty 0 >/dev/null
+  gpioctl -f /dev/gpioc2 5 duty 0 >/dev/null
+  sysctl -q dev.gpio.2.led.2.pwm=1
+  gpioctl -f /dev/gpioc2 6 duty 0 >/dev/null
+  gpioctl -f /dev/gpioc2 7 duty 0 >/dev/null
+  gpioctl -f /dev/gpioc2 8 duty 0 >/dev/null
 fi

--- a/deviceonline.sh
+++ b/deviceonline.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+pfctl -vvss | grep ', rule 79' >/dev/null
+res=$?
+if [ $res = 0 ]; then
+  sysctl -q dev.gpio.2.led.2.pwm=1
+  gpioctl -f /dev/gpioc2 6 duty 1 >/dev/null
+fi


### PR DESCRIPTION
This will light the led based on firewall rule number if a state is active set to what ever firewall ID you need. The example for me is 79



Ref:
https://forum.netgate.com/topic/182391/2100-led-question
https://forums.freebsd.org/threads/bin-sh-how-to-save-a-shell-command-output-into-a-string-variable.90088